### PR TITLE
fix domain names which ends with digits to be resolved correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 xip
 xip.linux
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xip
 xip.linux
+.idea/

--- a/xip.go
+++ b/xip.go
@@ -54,7 +54,7 @@ var (
 	addr    = flag.String("addr", ":53", "The addr to bind on")
 	ip      = flag.String("ip", "188.166.43.179", "The IP of xip.name")
 
-	ipPattern = regexp.MustCompile(`(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`)
+	ipPattern = regexp.MustCompile(`(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})`)
 	defaultIP net.IP
 )
 

--- a/xip_test.go
+++ b/xip_test.go
@@ -60,6 +60,8 @@ func TestDnsRR(t *testing.T) {
 	}{
 		{"abc", "abc\t300\tIN\tA\t"},
 		{"xyz", "xyz\t300\tIN\tA\t"},
+		{"nr1.10.0.0.1", "nr1.10.0.0.1\t300\tIN\tA\t10.0.0.1"},
+		{"sub.10.0.0.1", "sub.10.0.0.1\t300\tIN\tA\t10.0.0.1"},
 	} {
 		rr := dnsRR(tt.name)
 


### PR DESCRIPTION
Hello,

if my domain looks like izopi4a22.100.100.100.100 it gets wrongly resolved. 

This pull request fixes it ( or at least based on my tests )